### PR TITLE
Add heartbeat task

### DIFF
--- a/components/ring_link/CMakeLists.txt
+++ b/components/ring_link/CMakeLists.txt
@@ -1,5 +1,6 @@
 idf_component_register(SRCS 
      "ring_link.c"
+     "heartbeat.c"
     INCLUDE_DIRS "include"
-    REQUIRES ring_link_lowlevel ring_link_internal ring_link_netif
+    REQUIRES ring_link_lowlevel ring_link_internal ring_link_netif esp_timer
 )

--- a/components/ring_link/heartbeat.c
+++ b/components/ring_link/heartbeat.c
@@ -1,0 +1,55 @@
+#include "heartbeat.h"
+
+#define HEARTBEAT_INTERVAL_SEC 5
+#define MAX_FAILURES 5  // Número de fallos consecutivos antes de considerar una placa como "out"
+
+static int heartbeat_id = 0;
+static bool heartbeat_received = false;
+static esp_timer_handle_t heartbeat_timer;
+static esp_timer_handle_t check_timer;
+static int failure_count = 0;
+
+static const char *TAG = "==> heartbeat";
+
+
+void offline_board_callback(int failure_count){
+    ESP_LOGE(TAG, "Hay una placa OFFLINE. Se invoca al callback. Luego de %d pruebas.", failure_count);
+}
+
+void send_heartbeat() {
+    heartbeat_id++;
+    const char msg[] = "HEARTBEAT...";
+    heartbeat_received = broadcast_to_siblings_heartbeat(msg, sizeof(msg));
+    ESP_LOGE(TAG, "Enviado heartbeat %d", heartbeat_id);
+}
+
+void check_heartbeat() {
+    if (!heartbeat_received) {
+        failure_count++;
+        ESP_LOGW("HEARTBEAT", "No se recibió el heartbeat %d. Fallo #%d", heartbeat_id, failure_count);
+        if (failure_count >= MAX_FAILURES) {
+            ESP_LOGE(TAG, "Se alcanzó el máximo de fallos. Placa considerada fuera de servicio.");
+            offline_board_callback(failure_count);
+        }
+    } else {
+        failure_count = 0;  // Reinicia el contador si se recibe el heartbeat
+    }
+}
+
+void heartbeat_timer_callback(void* arg) {
+    send_heartbeat();
+    check_heartbeat();
+}
+
+void check_timer_callback(void* arg) {
+}
+
+void init_heartbeat(void) {
+    esp_timer_create_args_t heartbeat_timer_args = {
+        .callback = &heartbeat_timer_callback,
+        .name = "heartbeat_timer"
+    };
+    ESP_ERROR_CHECK(esp_timer_create(&heartbeat_timer_args, &heartbeat_timer));
+    ESP_ERROR_CHECK(esp_timer_start_periodic(heartbeat_timer, HEARTBEAT_INTERVAL_SEC * 1000000));
+
+}

--- a/components/ring_link/heartbeat.c
+++ b/components/ring_link/heartbeat.c
@@ -16,6 +16,10 @@ void offline_board_callback(int failure_count){
     ESP_LOGE(TAG, "Hay una placa OFFLINE. Se invoca al callback. Luego de %d pruebas.", failure_count);
 }
 
+void online_board_callback(){
+    ESP_LOGE(TAG, "El nodo se encuentra ONLINE. Se invoca al callback.");
+}
+
 void send_heartbeat() {
     heartbeat_id++;
     const char msg[] = "HEARTBEAT...";
@@ -33,6 +37,7 @@ void check_heartbeat() {
         }
     } else {
         failure_count = 0;  // Reinicia el contador si se recibe el heartbeat
+        online_board_callback();
     }
 }
 

--- a/components/ring_link/include/heartbeat.h
+++ b/components/ring_link/include/heartbeat.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <esp_timer.h>
+#include <esp_log.h>
+
+#include "ring_link_lowlevel.h"
+#include "ring_link_internal.h"
+#include "ring_link_netif.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void init_heartbeat(void);
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/components/ring_link/ring_link.c
+++ b/components/ring_link/ring_link.c
@@ -16,6 +16,7 @@ static void ring_link_receive_task( void *pvParameters )
         switch (p.buffer_type)
         {
         case RING_LINK_PAYLOAD_TYPE_INTERNAL:
+        case RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT:
             ESP_ERROR_CHECK_WITHOUT_ABORT(ring_link_internal_handler(&p));
             break;
         case RING_LINK_PAYLOAD_TYPE_ESP_NETIF:

--- a/components/ring_link_internal/include/ring_link_internal.h
+++ b/components/ring_link_internal/include/ring_link_internal.h
@@ -12,6 +12,10 @@ extern "C" {
 
 bool broadcast_to_siblings(const void *msg, uint16_t len);
 
+bool broadcast_to_siblings_heartbeat(const void *msg, uint16_t len);
+
+bool ring_link_send_heartbeat(const void *msg, uint16_t len);
+
 esp_err_t ring_link_internal_init(void);
 
 esp_err_t ring_link_internal_handler(ring_link_payload_t *p);

--- a/components/ring_link_internal/ring_link_internal.c
+++ b/components/ring_link_internal/ring_link_internal.c
@@ -25,6 +25,9 @@ esp_err_t ring_link_internal_init( void )
 
 static esp_err_t ring_link_process(ring_link_payload_t *p)
 {
+    if (ring_link_payload_is_heartbeat(p)){
+        return ESP_OK;
+    }
     printf("call on_sibling_message(%s, %i)\n", p->buffer, p->len);
     return ESP_OK;
 }
@@ -80,10 +83,6 @@ static esp_err_t ring_link_broadcast_handler(ring_link_payload_t *p)
         xQueueSend(s_broadcast_queue, (void *) &(p->id), ( TickType_t ) 0 );
         ESP_LOGI(TAG, "Broadcast complete for packet id '%i'.", p->id);
         return ESP_OK;
-    }
-    else if (ring_link_payload_is_heartbeat(p))
-    {
-        return ring_link_lowlevel_forward_payload(p);
     }
     else
     {

--- a/components/ring_link_internal/ring_link_internal.c
+++ b/components/ring_link_internal/ring_link_internal.c
@@ -44,17 +44,17 @@ static esp_err_t ring_link_broadcast(const void *buffer, uint16_t len, ring_link
 
 bool broadcast_to_siblings_internal(const void *msg, uint16_t len, ring_link_payload_buffer_type_t buffer_type)
 {
-    if( xSemaphoreTake( s_broadcast_semaphore_handle, ( TickType_t ) 10 ) == pdTRUE )
+    if( xSemaphoreTake( s_broadcast_semaphore_handle, ( TickType_t ) 100 ) == pdTRUE )
     {
         esp_err_t rc = ring_link_broadcast(msg, len, buffer_type);
         uint8_t id;
-        if( xQueueReceive( s_broadcast_queue, &( id ), ( TickType_t ) 10 ) == pdPASS )
+        bool result = false;
+        if( xQueueReceive( s_broadcast_queue, &( id ), ( TickType_t ) 100 ) == pdPASS )
         {
-            xSemaphoreGive( s_broadcast_semaphore_handle );
-            return rc == ESP_OK ? true : false;
+            result = (rc == ESP_OK);
         }
-        
-        return false;
+        xSemaphoreGive( s_broadcast_semaphore_handle );
+        return result;
     }
     ESP_LOGE(TAG, "Could not adquire Mutex...");
     return false;

--- a/components/ring_link_internal/ring_link_internal.c
+++ b/components/ring_link_internal/ring_link_internal.c
@@ -29,24 +29,24 @@ static esp_err_t ring_link_process(ring_link_payload_t *p)
     return ESP_OK;
 }
 
-static esp_err_t ring_link_broadcast(const void *buffer, uint16_t len){
+static esp_err_t ring_link_broadcast(const void *buffer, uint16_t len, ring_link_payload_buffer_type_t buffer_type){
     ring_link_payload_t p = {
         .id = 0,
         .ttl = RING_LINK_PAYLOAD_TTL,
         .src_device_id = device_config_get_id(),
         .dst_device_id = DEVICE_ID_ALL,
-        .buffer_type = RING_LINK_PAYLOAD_TYPE_INTERNAL,
+        .buffer_type = buffer_type,
         .len = len,
     };
     memccpy(p.buffer, buffer, len, RING_LINK_PAYLOAD_BUFFER_SIZE);
     return ring_link_lowlevel_transmit_payload(&p);
 }
 
-bool broadcast_to_siblings(const void *msg, uint16_t len)
+bool broadcast_to_siblings_internal(const void *msg, uint16_t len, ring_link_payload_buffer_type_t buffer_type)
 {
     if( xSemaphoreTake( s_broadcast_semaphore_handle, ( TickType_t ) 10 ) == pdTRUE )
     {
-        esp_err_t rc = ring_link_broadcast(msg, len);
+        esp_err_t rc = ring_link_broadcast(msg, len, buffer_type);
         uint8_t id;
         if( xQueueReceive( s_broadcast_queue, &( id ), ( TickType_t ) 10 ) == pdPASS )
         {
@@ -60,6 +60,18 @@ bool broadcast_to_siblings(const void *msg, uint16_t len)
     return false;
 }
 
+bool broadcast_to_siblings_heartbeat(const void *msg, uint16_t len){
+    
+    ring_link_payload_buffer_type_t buffer_type = RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT;
+    return broadcast_to_siblings_internal(msg, len, buffer_type);
+}
+
+bool broadcast_to_siblings(const void *msg, uint16_t len){
+    
+    ring_link_payload_buffer_type_t buffer_type = RING_LINK_PAYLOAD_TYPE_INTERNAL;
+    return broadcast_to_siblings_internal(msg, len, buffer_type);
+}
+
 static esp_err_t ring_link_broadcast_handler(ring_link_payload_t *p)
 {
     // broadcast origin
@@ -68,6 +80,10 @@ static esp_err_t ring_link_broadcast_handler(ring_link_payload_t *p)
         xQueueSend(s_broadcast_queue, (void *) &(p->id), ( TickType_t ) 0 );
         ESP_LOGI(TAG, "Broadcast complete for packet id '%i'.", p->id);
         return ESP_OK;
+    }
+    else if (ring_link_payload_is_heartbeat(p))
+    {
+        return ring_link_lowlevel_forward_payload(p);
     }
     else
     {

--- a/components/ring_link_lowlevel/include/ring_link_payload.h
+++ b/components/ring_link_lowlevel/include/ring_link_payload.h
@@ -15,10 +15,16 @@ extern "C" {
 #define RING_LINK_PAYLOAD_BUFFER_SIZE RING_LINK_LOWLEVEL_BUFFER_SIZE
 #define RING_LINK_PAYLOAD_TTL 4
 
-typedef enum {
-    RING_LINK_PAYLOAD_TYPE_INTERNAL = 0,
-    RING_LINK_PAYLOAD_TYPE_ESP_NETIF = 1,
+typedef enum: uint8_t {
+    RING_LINK_PAYLOAD_TYPE_INTERNAL = 0x00,
+    RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT = 0x01,
+    
+    RING_LINK_PAYLOAD_TYPE_ESP_NETIF = 0x80,
 } ring_link_payload_buffer_type_t;
+
+#define IS_INTERNAL_PAYLOAD(type) ((type) < 0x80)
+#define IS_EXTERNAL_PAYLOAD(type) ((type) >= 0x80)
+#define IS_HEARTBEAT_PAYLOAD(type) ((type) == RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT)
 
 typedef uint8_t ring_link_payload_id_t;
 
@@ -38,6 +44,9 @@ bool ring_link_payload_is_for_device(ring_link_payload_t *p);
 bool ring_link_payload_is_from_device(ring_link_payload_t *p);
 
 bool ring_link_payload_is_broadcast(ring_link_payload_t *p);
+
+bool ring_link_payload_is_heartbeat(ring_link_payload_t *p);
+
 
 #ifdef __cplusplus
 }

--- a/components/ring_link_lowlevel/include/ring_link_payload.h
+++ b/components/ring_link_lowlevel/include/ring_link_payload.h
@@ -15,6 +15,21 @@ extern "C" {
 #define RING_LINK_PAYLOAD_BUFFER_SIZE RING_LINK_LOWLEVEL_BUFFER_SIZE
 #define RING_LINK_PAYLOAD_TTL 4
 
+/**
+ * @brief Types of payloads in the ring link communication.
+ *
+ * This enumeration defines the various types of payloads that can be
+ * transmitted in the ring link system. The values are carefully chosen
+ * to distinguish between internal and external payloads.
+ *
+ * Internal payloads (< 0x80):
+ * - Used for communication within the ring link system itself.
+ * - Include types like regular internal messages and heartbeats.
+ *
+ * External payloads (>= 0x80):
+ * - Used for payloads originating from or destined to external systems.
+ * - Include types like ESP-NETIF messages.
+ */
 typedef enum: uint8_t {
     RING_LINK_PAYLOAD_TYPE_INTERNAL = 0x00,
     RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT = 0x01,
@@ -22,8 +37,6 @@ typedef enum: uint8_t {
     RING_LINK_PAYLOAD_TYPE_ESP_NETIF = 0x80,
 } ring_link_payload_buffer_type_t;
 
-#define IS_INTERNAL_PAYLOAD(type) ((type) < 0x80)
-#define IS_EXTERNAL_PAYLOAD(type) ((type) >= 0x80)
 #define IS_HEARTBEAT_PAYLOAD(type) ((type) == RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT)
 
 typedef uint8_t ring_link_payload_id_t;

--- a/components/ring_link_lowlevel/ring_link_payload.c
+++ b/components/ring_link_lowlevel/ring_link_payload.c
@@ -18,3 +18,8 @@ bool ring_link_payload_is_broadcast(ring_link_payload_t *p)
 {
     return p->dst_device_id == DEVICE_ID_ALL;
 }
+
+bool ring_link_payload_is_heartbeat(ring_link_payload_t *p)
+{
+    return IS_HEARTBEAT_PAYLOAD(p->buffer_type);
+}

--- a/main/main.c
+++ b/main/main.c
@@ -8,6 +8,7 @@
 // Private components
 #include "config.h"
 #include "ring_link.h"
+#include "heartbeat.h"
 #include "udp_spi.h"
 #include "wifi.h"
 #include "route.h"
@@ -18,7 +19,7 @@
 #include "test_integration.h"
 #include "test_spi.h"
 
-#define TEST_ALL true
+#define TEST_ALL false
 
 static const char *TAG = "==> main";
 
@@ -35,19 +36,16 @@ void app_main(void)
     bind_udp_spi();
     test_spi_run_all();
 
-
     ESP_ERROR_CHECK(wifi_init());
     ESP_ERROR_CHECK(wifi_netif_init());
 
-    add_route("192.168.0.0", WIFI_GATEWAY, "255.255.0.0", "r_1");
-    add_route("192.168.60.0", WIFI_GATEWAY, "255.255.255.128", "r_3");
-    add_route("192.168.60.0", SPI_GATEWAY, "255.255.255.0", "r_2");
+    // add_route("192.168.0.0", WIFI_GATEWAY, "255.255.0.0", "r_1");
+    // add_route("192.168.60.0", WIFI_GATEWAY, "255.255.255.128", "r_3");
+    // add_route("192.168.60.0", SPI_GATEWAY, "255.255.255.0", "r_2");
     print_route_table();
 
-    test(TEST_ALL);
 
-    rm_route("192.168.60.0", "255.255.254.0");
-    print_route_table();
+    // rm_route("192.168.60.0", "255.255.254.0");
     #ifdef CONFIG_RING_LINK_LOWLEVEL_IMPL_SPI
     printf("CONFIG_RING_LINK_LOWLEVEL_IMPL_SPI\n");
     #endif
@@ -55,4 +53,9 @@ void app_main(void)
     #ifdef CONFIG_RING_LINK_LOWLEVEL_IMPL_UART
     printf("CONFIG_RING_LINK_LOWLEVEL_IMPL_UART\n");
     #endif
+    
+    print_route_table();
+    
+    test(TEST_ALL);
+    init_heartbeat();
 }


### PR DESCRIPTION
El cambio del enum

```
typedef enum: uint8_t {
    RING_LINK_PAYLOAD_TYPE_INTERNAL = 0x00,
    RING_LINK_PAYLOAD_TYPE_INTERNAL_HEARTBEAT = 0x01,
    
    RING_LINK_PAYLOAD_TYPE_ESP_NETIF = 0x80,
} ring_link_payload_buffer_type_t;
```
es para hacer más eficiente el header, entiendo que un enum de enteros es de 32 bits y de esta manera serían de 8 bits.